### PR TITLE
Recognize comma separated lists

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -147,11 +147,11 @@ class App extends AbstractApp {
 			new \Twig_Extension_Debug(),
 			new LinkifyExtension( array(
 				// Gerrit change-id
-				'/(?<=^|\s)\b(I[0-9a-f]{6,})\b(?=\s|:|$)/' => array(
+				'/(?<=^|\s)\b(I[0-9a-f]{6,})\b(?=\s|:|,|$)/' => array(
 					'https://gerrit.wikimedia.org/r/#/q/$1,n,z', '$1'
 				),
 				// Git commit hash
-				'/(?<=^|\s|\(|\[)\b([0-9a-f]{7,})\b(?=\s|:|\)|\]|$)/' => array(
+				'/(?<=^|\s|\(|\[)\b([0-9a-f]{7,})\b(?=\s|:|,|\)|\]|$)/' => array(
 					'https://gerrit.wikimedia.org/r/#/q/$1,n,z', '$1'
 				),
 				// Gerrit patch


### PR DESCRIPTION
Recognize comma separated list of Gerrit change-id or Git commit hash
for linkifying purposes.

These are common in e.g. https://tools.wmflabs.org/sal/tools.heritage
