### PR TITLE
Add Atom feed for each SAL

### DIFF
--- a/data/templates/base.html
+++ b/data/templates/base.html
@@ -9,7 +9,7 @@
     <link rel="shortcut icon" type="image/x-icon" href="{{ siteUrl( 'favicon.ico' ) }}">
     <link rel="icon" type="image/x-icon" href="{{ siteUrl( 'favicon.ico' ) }}">
     <link rel="stylesheet" type="text/css" href="{{ siteUrl( 'assets/main.css' ) }}">
-    {% block css %}{% endblock css %}
+    {% block head %}{% endblock head %}
     <title>{% block title %}{{ 'header-title'|message }}{% endblock title %}</title>
   </head>
   <body>

--- a/data/templates/sal.atom
+++ b/data/templates/sal.atom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ project }}</title>
+  <link href="{{ siteUrl( urlFor( 'SAL (Atom)', { 'project': project } ) ) }}" rel="self" />
+  <link href="{{ siteUrl( urlFor( 'SAL', { 'project': project } ) ) }}" />
+  <id>{{ siteUrl( urlFor( 'SAL', { 'project': project } ) ) }}</id>
+  {% if results %}
+  {% set latest_result_data = results[0].getData() %}
+  <updated>{{ latest_result_data['@timestamp'] }}</updated>
+  {% for log in results %}
+  <entry>
+    {% set data = log.getData() %}
+    <title>{{ data['message'] }}</title>
+    <link href="{{ siteUrl( urlFor( 'log', { 'id': log.getId() } ) ) }}" />
+    <id>{{ siteUrl( urlFor( 'log', { 'id': log.getId() } ) ) }}</id>
+    <published>{{ data['@timestamp'] }}</published>
+    <updated>{{ data['@timestamp'] }}</updated>
+    <content type="xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        {{ data['message']|linkify }}
+      </div>
+    </content>
+    <author>
+      <name>{{ data['nick'] }}</name>
+    </author>
+  </entry>
+  {% endfor %}
+  {% endif %}
+</feed>

--- a/data/templates/sal.html
+++ b/data/templates/sal.html
@@ -5,6 +5,10 @@
 {% set last = min( first + i - 1, all ) %}
 {% set last_day = '' %}
 
+{% block head %}
+<link href="{{ urlFor( 'SAL (Atom)', { 'project': project } ) }}" type="application/atom+xml" rel="alternate" title="Atom feed" />
+{% endblock head %}
+
 {% block title %}{{ 'title-sal'|message( project ) }} - {{ parent() }}{% endblock title %}
 
 {% block content %}

--- a/src/App.php
+++ b/src/App.php
@@ -220,6 +220,13 @@ class App extends AbstractApp {
 					$page->setLogs( $slim->logs );
 					$page( $project );
 				} )->name( 'SAL' );
+
+				$slim->get( 'atom/(:project)', function ( $project = 'production' ) use ( $slim ) {
+					$page = new Pages\SalAtom( $slim );
+					$page->setI18nContext( $slim->i18nContext );
+					$page->setLogs( $slim->logs );
+					$page( $project );
+				} )->name( 'SAL (Atom)' );
 			}
 		); // end group '/'
 

--- a/src/App.php
+++ b/src/App.php
@@ -221,7 +221,7 @@ class App extends AbstractApp {
 					$page( $project );
 				} )->name( 'SAL' );
 
-				$slim->get( 'atom/(:project)', function ( $project = 'production' ) use ( $slim ) {
+				$slim->get( 'atom/(:project)', static function ( $project = 'production' ) use ( $slim ) {
 					$page = new Pages\SalAtom( $slim );
 					$page->setI18nContext( $slim->i18nContext );
 					$page->setLogs( $slim->logs );

--- a/src/Pages/SalAtom.php
+++ b/src/Pages/SalAtom.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of bd808's sal application
+ * Copyright (C) 2015  Bryan Davis and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bd808\Sal\Pages;
+
+use Bd808\Sal\Page;
+
+/**
+ * @author Bryan Davis <bd808@wikimedia.org>
+ * @copyright © 2015 Bryan Davis and contributors.
+ */
+class SalAtom extends Page {
+	protected function handleGet( $project ) {
+		$params = [
+			'project' => $project,
+			'query' => null,
+			'page' => 0,
+			'items' => 50,
+			'date' => null,
+		];
+		$ret = $this->logs->search( $params );
+
+		$this->view->set( 'project', $project );
+		$this->view->set( 'results', $ret );
+
+		$this->response->headers->set( 'Content-Type', 'application/atom+xml' );
+
+		$this->render( 'sal.atom' );
+	}
+}


### PR DESCRIPTION
This makes it possible to subscribe to any given SAL (production, releng, specific tool, whatever you want) using any standard feed reader, at URLs like <https://sal.toolforge.org/atom/> (production) or <https://sal.toolforge.org/atom/tools.stashbot> (specific log). We use Atom instead of RSS because RSS requires the author field to contain an email address, which we don’t have. Use the plain-text message as the title and the linkified version as the (X)HTML content.

In base.html, rename `{% block css %}` to `{% block head %}` (we need to customize the block to add a link pointing to the Atom feed in the `sal.html` template, and “css” makes less sense in that context); it had not been used under its old name, as far as I can tell, so there are no other references to update.

Bug: [T324703](https://phabricator.wikimedia.org/T324703)