### PR TITLE
log.html: add UTC to timestamps

### DIFF
--- a/data/templates/log.html
+++ b/data/templates/log.html
@@ -8,7 +8,7 @@
   {% set data = log.getData() %}
   <tbody>
   <tr>
-    <th colspan="4">{{ data['@timestamp']|date('Y-m-d') }} - <a href="{{ urlFor( 'SAL', { 'project': data['project'] } ) }}">{{ data['project'] }}</a></th>
+    <th colspan="4">{{ data['@timestamp']|date('Y-m-d') }} UTC - <a href="{{ urlFor( 'SAL', { 'project': data['project'] } ) }}">{{ data['project'] }}</a></th>
   </tr>
   {% include 'inc/log.html' %}
   {% endfor %}


### PR DESCRIPTION
That way it's clear that they are expected to be UTC times.

There might be a smarter way of getting the tz, have not investigated much, but for what I can tell we are just expecting it to be UTC, so just surfacing that assumption in the UI.